### PR TITLE
Fixed sigsegv - mingw++ on Windows 32bit only

### DIFF
--- a/TraceMiner2/tmcursor.cpp
+++ b/TraceMiner2/tmcursor.cpp
@@ -59,6 +59,7 @@
 tmCursor::~tmCursor() {
     // Anything to do to kill a tmCursor?
     // Of course there is, get shot of all the binds in the map.
+    //cerr << endl << "Deleting Cursor: " << mCursorId; // Debugging.
     cleanUp();
 }
 
@@ -72,11 +73,19 @@ tmCursor::~tmCursor() {
  */
 void tmCursor::cleanUp() {
 
-    for (map<unsigned, tmBind *>::iterator i = mBinds.begin(); i != mBinds.end(); ++i) {
-        // Dump the bind details for debugging.
-        //cerr << *(i->second);
-        mBinds.erase(i);
-        delete i->second;
+    //short bindCount = 0;
+    if (mBinds.size()) {
+        for (map<unsigned, tmBind *>::iterator i = mBinds.begin(); i != mBinds.end(); ++i) {
+            // Dump the bind details for debugging.
+            //cerr << "cleanUp(): Bind number: " << bindCount++ << endl;
+            //cerr << *(i->second);
+
+            // Destruct this particular tmBind.
+            delete i->second;
+        }
+
+        // Finally, clear the map.
+        mBinds.clear();
     }
 }
 

--- a/TraceMiner2/tmoptions.cpp
+++ b/TraceMiner2/tmoptions.cpp
@@ -78,7 +78,7 @@ bool tmOptions::parseArgs(int argc, char *argv[]) {
         // Convert args to lower case and to strings.
         // Not really safe with Unicode though!
         string thisArg = string(argv[arg]);
-        for (int c = 0; c < thisArg.length(); c++) {
+        for (int c = 0; c < (int)thisArg.length(); c++) {
             thisArg[c] = tolower(thisArg[c]);
         }
 

--- a/TraceMiner2/tmtracefile.cpp
+++ b/TraceMiner2/tmtracefile.cpp
@@ -743,9 +743,13 @@ void tmTraceFile::cleanUp() {
                 *mDbg << endl << "cleanUP(): Freeing cursor: " << i->second->cursorId() << endl;
                 *mDbg << *(i->second);
             }
-            mCursors.erase(i);
+
+            // Destruct the tmCursor.
             delete i->second;
         }
+
+        // Finally, clear the map.
+        mCursors.clear();
     }
 
     // we must do this last of all, or the above might blow up!


### PR DESCRIPTION
Closing a trace file caused a sigsegv when compiled with mingw++ 32bit on WIndows 7.
Caused by the deletion of map entries for binds for the cursor being closed.
Interesting one to track down though!